### PR TITLE
feat: add basic SFU server skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ package-lock.json
 demo-server/dist
 demo-server/node_modules
 demo-server/media
+server/node_modules
+server/video

--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ See [DEMO_SFU_SERVER_REQUIREMENTS.md](DEMO_SFU_SERVER_REQUIREMENTS.md) for the d
 
 ## Server
 
-The SFU demo server implementation lives in the [`server/`](server) directory. It exposes:
+The SFU server implementation lives in the [`server/`](server) directory. It exposes:
 
+- `POST /api/session/start` – allocate an RTP port and begin recording the incoming H.264 stream to MP4
+- `POST /api/session/stop` – stop recording and close the session
 - `GET /healthz` – basic health check
-- `GET /catalog` – media catalog generated from `MEDIA_DIR` (use `?count=n` to duplicate streams)
-- `ws://localhost:<PORT>/ws` – WebSocket API for stream control
+- `ws://localhost:<PORT>/ws` – WebSocket API for stream control (`subscribe`/`unsubscribe`)
 
 To run the server locally:
 
@@ -20,13 +21,12 @@ npm install
 npm run dev
 ```
 
-By default the server looks for MP4 files under `../media` and listens on port `8080`. Set `STREAM_COUNT` to expand the initial catalog.
-
-All streams are served in the same quality profile; there is no separate unselected stream.
+By default the server stores recordings under
+`./video/{trainingId}/{sessionId}/{studentId}/{streamKey}.mp4` and listens on
+port `8080`.
 
 Example WebSocket subscribe message:
 
 ```json
-{ "type": "subscribe", "streamKey": "WELD-A1" }
+{ "type": "subscribe", "streamKey": "cam01" }
 ```
-

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,39 @@
+# SFU Server
+
+A minimal SFU-like server that accepts RTP(H.264) streams from Android tablets,
+forwards control via WebSocket and records the streams to MP4 files without
+re-encoding.
+
+## API
+
+### POST /api/session/start
+Request body:
+```
+{ "trainingId": "T001", "sessionId": "S001", "studentId": "ST001", "streamKey": "cam01" }
+```
+Response:
+```
+{ "status": "ready", "rtpUrl": "rtp://localhost:5000" }
+```
+
+### POST /api/session/stop
+Request body:
+```
+{ "streamKeys": ["cam01"] }
+```
+
+### WebSocket `/ws`
+Supports `subscribe` and `unsubscribe` messages:
+```
+{ "type": "subscribe", "streamKey": "cam01" }
+```
+
+## Running
+```
+cd server
+npm install
+npm run dev
+```
+
+By default the server listens on port `8080` and stores recordings under
+`./video/{trainingId}/{sessionId}/{studentId}/{streamKey}.mp4`.

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "sfu-server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node src/index.js",
+    "start": "node src/index.js",
+    "test": "echo 'No tests'"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "ws": "^8.13.0"
+  }
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,0 +1,105 @@
+import express from 'express';
+import { WebSocketServer } from 'ws';
+import { spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+const PORT = process.env.PORT || 8080;
+const VIDEO_ROOT = process.env.VIDEO_ROOT || path.join(process.cwd(), 'video');
+const RTP_BASE_PORT = parseInt(process.env.RTP_BASE_PORT || '5000', 10);
+
+const app = express();
+app.use(express.json());
+
+// in-memory session tracking
+const sessions = new Map(); // streamKey -> {ffmpeg, port, filePath}
+let nextPort = RTP_BASE_PORT;
+
+function allocatePort() {
+  return nextPort++;
+}
+
+app.get('/healthz', (_, res) => {
+  res.status(200).send('ok');
+});
+
+app.post('/api/session/start', (req, res) => {
+  const { trainingId, sessionId, studentId, streamKey } = req.body || {};
+  if (!trainingId || !sessionId || !studentId || !streamKey) {
+    res.status(400).json({ error: 'missing parameter' });
+    return;
+  }
+  if (sessions.has(streamKey)) {
+    res.status(400).json({ error: 'stream already started' });
+    return;
+  }
+
+  const port = allocatePort();
+  const dir = path.join(VIDEO_ROOT, trainingId, sessionId, studentId);
+  fs.mkdirSync(dir, { recursive: true });
+  const filePath = path.join(dir, `${streamKey}.mp4`);
+
+  const ffmpegArgs = [
+    '-loglevel', 'error',
+    '-i', `rtp://0.0.0.0:${port}`,
+    '-c', 'copy',
+    '-f', 'mp4',
+    filePath,
+  ];
+  const ffmpeg = spawn('ffmpeg', ffmpegArgs);
+
+  ffmpeg.on('exit', (code) => {
+    console.log(`ffmpeg for ${streamKey} exited with code ${code}`);
+  });
+
+  sessions.set(streamKey, { ffmpeg, port, filePath });
+
+  res.json({ status: 'ready', rtpUrl: `rtp://localhost:${port}` });
+});
+
+app.post('/api/session/stop', (req, res) => {
+  const { streamKeys } = req.body || {};
+  if (!Array.isArray(streamKeys)) {
+    res.status(400).json({ error: 'streamKeys must be array' });
+    return;
+  }
+
+  streamKeys.forEach((key) => {
+    const session = sessions.get(key);
+    if (session) {
+      session.ffmpeg.kill('SIGINT');
+      sessions.delete(key);
+    }
+  });
+
+  res.json({ status: 'stopped' });
+});
+
+const server = app.listen(PORT, () => {
+  console.log(`SFU server listening on port ${PORT}`);
+});
+
+const wss = new WebSocketServer({ server, path: '/ws' });
+
+wss.on('connection', (ws) => {
+  ws.on('message', (data) => {
+    let msg;
+    try {
+      msg = JSON.parse(data.toString());
+    } catch (err) {
+      ws.send(JSON.stringify({ type: 'error', message: 'invalid json' }));
+      return;
+    }
+
+    switch (msg.type) {
+      case 'subscribe':
+        ws.send(JSON.stringify({ type: 'subscribed', streamKey: msg.streamKey }));
+        break;
+      case 'unsubscribe':
+        ws.send(JSON.stringify({ type: 'unsubscribed', streamKey: msg.streamKey }));
+        break;
+      default:
+        ws.send(JSON.stringify({ type: 'error', message: 'unknown type' }));
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add initial SFU server with session start/stop APIs and WebSocket control
- document running the server and adjust repository README
- update gitignore for server artifacts

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7ec7510548328872f218b732ad4b1